### PR TITLE
Add check for already running daemon and custom ports for own daemon

### DIFF
--- a/app/api.js
+++ b/app/api.js
@@ -9,7 +9,6 @@ import pjson from '../package.json'
 import gateways from './gateways.json'
 
 import Settings from 'electron-settings'
-import { getApiMultiAddress } from './daemon'
 
 export const ERROR_IPFS_UNAVAILABLE = 'IPFS NOT AVAILABLE'
 export const ERROR_IPFS_TIMEOUT = 'TIMEOUT'
@@ -21,7 +20,17 @@ export function setClientInstance (client) {
   IPFS_CLIENT = client
 }
 
-export function initIPFSClient () {
+/**
+ * initIPFSClient will set up a new ipfs-api instance. It has an optional
+ * argument `apiMultiaddr` that contains the custom multiaddr for the API.
+ * If `apiMultiaddr` is not provided, the initIPFSClient is assuming that it is
+ * running from a window, and it will extract the client from the global var in
+ * the main process (using Electron remote)
+ *
+ * @param {string} apiMultiaddr
+ * @returns Promise<IPFS_CLIENT>
+ */
+export function initIPFSClient (apiMultiaddr) {
   if (IPFS_CLIENT !== null) return Promise.resolve(IPFS_CLIENT)
 
   // get IPFS client from the main process
@@ -34,11 +43,8 @@ export function initIPFSClient () {
   }
 
   // this fails because of the repo lock
-  return getApiMultiAddress()
-    .then(apiMultiaddr => {
-      setClientInstance(ipfsAPI(apiMultiaddr))
-      return Promise.resolve(IPFS_CLIENT)
-    })
+  setClientInstance(ipfsAPI(apiMultiaddr))
+  return Promise.resolve(IPFS_CLIENT)
 }
 
 /**

--- a/app/api.js
+++ b/app/api.js
@@ -21,16 +21,12 @@ export function setClientInstance (client) {
 }
 
 /**
- * initIPFSClient will set up a new ipfs-api instance. It has an optional
- * argument `apiMultiaddr` that contains the custom multiaddr for the API.
- * If `apiMultiaddr` is not provided, the initIPFSClient is assuming that it is
- * running from a window, and it will extract the client from the global var in
- * the main process (using Electron remote)
+ * initIPFSClient will set up a new ipfs-api instance. It will try to get an
+ * existing instance and the configuration (api endpoint) from global vars
  *
- * @param {string} apiMultiaddr
  * @returns Promise<IPFS_CLIENT>
  */
-export function initIPFSClient (apiMultiaddr) {
+export function initIPFSClient () {
   if (IPFS_CLIENT !== null) return Promise.resolve(IPFS_CLIENT)
 
   // get IPFS client from the main process
@@ -40,6 +36,14 @@ export function initIPFSClient (apiMultiaddr) {
       setClientInstance(globalClient)
       return Promise.resolve(IPFS_CLIENT)
     }
+  }
+  // Configure the endpoint for the api. It will try to get the value from the
+  // global variables IPFS_MULTIADDR_APIs
+  let apiMultiaddr
+  if (remote) {
+    apiMultiaddr = remote.getGlobal('IPFS_MULTIADDR_API')
+  } else if (global.IPFS_MULTIADDR_API) {
+    apiMultiaddr = global.IPFS_MULTIADDR_API
   }
 
   // this fails because of the repo lock

--- a/app/api.js
+++ b/app/api.js
@@ -9,7 +9,7 @@ import pjson from '../package.json'
 import gateways from './gateways.json'
 
 import Settings from 'electron-settings'
-import { getMultiAddrIPFSDaemon } from './daemon'
+import { getApiMultiAddress } from './daemon'
 
 export const ERROR_IPFS_UNAVAILABLE = 'IPFS NOT AVAILABLE'
 export const ERROR_IPFS_TIMEOUT = 'TIMEOUT'
@@ -33,9 +33,12 @@ export function initIPFSClient () {
     }
   }
 
-  const apiMultiaddr = getMultiAddrIPFSDaemon()
-  setClientInstance(ipfsAPI(apiMultiaddr))
-  return Promise.resolve(IPFS_CLIENT)
+  // this fails because of the repo lock
+  return getApiMultiAddress()
+    .then(apiMultiaddr => {
+      setClientInstance(ipfsAPI(apiMultiaddr))
+      return Promise.resolve(IPFS_CLIENT)
+    })
 }
 
 /**

--- a/app/api.test.js
+++ b/app/api.test.js
@@ -57,6 +57,7 @@ describe('api.js', () => {
         })
     })
   })
+
   describe('resolveName', function () {
     it('should reject when IPFS is not started', function () {
       // arrange

--- a/app/api.test.js
+++ b/app/api.test.js
@@ -7,20 +7,18 @@ import request from 'request-promise-native'
 import pjson from '../package'
 // import Settings from 'electron-settings'
 
-jest.mock('./daemon', () => {
-  return {
-    getApiMultiAddress: jest.fn().mockReturnValue(Promise.resolve('my-address'))
-  }
-})
 jest.mock('ipfs-api', () => {
   return jest.fn().mockReturnValue('new-instance')
 })
+
 jest.mock('./gateways', () => {
   return ['mock-gateway-1', 'mock-gateway-2']
 })
+
 jest.mock('request-promise-native', () => {
   return jest.fn().mockReturnValue(Promise.resolve())
 })
+
 jest.mock('electron-settings', () => {
   const getSyncMock = jest.fn()
     // getSync('skipGatewayQuery)
@@ -49,11 +47,11 @@ describe('api.js', () => {
     it('should create a new instance', () => {
       // arrange
       api.setClientInstance(null)
+      global.IPFS_MULTIADDR_API = 'my-address'
       // act
       return api.initIPFSClient()
         .then(result => {
           // assert
-          expect(daemon.getApiMultiAddress).toHaveBeenCalled()
           expect(ipfsApi).toBeCalledWith('my-address')
           expect(result).toBe('new-instance')
         })

--- a/app/api.test.js
+++ b/app/api.test.js
@@ -9,7 +9,7 @@ import pjson from '../package'
 
 jest.mock('./daemon', () => {
   return {
-    getMultiAddrIPFSDaemon: jest.fn().mockReturnValue('my-address')
+    getApiMultiAddress: jest.fn().mockReturnValue(Promise.resolve('my-address'))
   }
 })
 jest.mock('ipfs-api', () => {
@@ -53,7 +53,7 @@ describe('api.js', () => {
       return api.initIPFSClient()
         .then(result => {
           // assert
-          expect(daemon.getMultiAddrIPFSDaemon).toHaveBeenCalled()
+          expect(daemon.getApiMultiAddress).toHaveBeenCalled()
           expect(ipfsApi).toBeCalledWith('my-address')
           expect(result).toBe('new-instance')
         })

--- a/app/api.test.js
+++ b/app/api.test.js
@@ -1,5 +1,4 @@
 import * as api from './api'
-import * as daemon from './daemon'
 import ipfsApi from 'ipfs-api'
 import multiaddr from 'multiaddr'
 import request from 'request-promise-native'

--- a/app/daemon.js
+++ b/app/daemon.js
@@ -22,7 +22,7 @@ export function executeIPFSCommand (...args) {
     console.log('Running', global.IPFS_BINARY_PATH, args)
     // We need to replace spaces with escaped spaces in each argument passed
     // this will prevent situation of arguments splitted by mistake: ex on macOS
-    args = args.map((el)=> { el.replace(' ', '\\ ') })
+    args = args.map((el) => { el.replace(' ', '\\ ') })
     // Build the cmd
     const cmd = global.IPFS_BINARY_PATH + args.join(' ')
     const child = exec(cmd, options)
@@ -35,7 +35,7 @@ export function executeIPFSCommand (...args) {
     // On close ensure that the Promise resolves
     child.on('close', (code) => {
       if (code !== 0) {
-        console.error(`Error running: ${global.IPFS_BINARY_PATH} ${args} ${options} - ${code}`);
+        console.error(`Error running: ${global.IPFS_BINARY_PATH} ${args} ${options} - ${code}`)
         return reject(code)
       }
       return resolve(output)

--- a/app/daemon.js
+++ b/app/daemon.js
@@ -151,7 +151,7 @@ export function ensuresIPFSInitialised () {
   if (isIPFSInitialised()) return Promise.resolve()
   console.log('Initialising IPFS repository...')
   return new Promise((resolve, reject) => {
-    const ipfsProcess = spawnIPFSCommand('init', `--api=${global.IPFS_MULTIADDR_API}`)
+    const ipfsProcess = spawnIPFSCommand('init')
     // Prepare temporary file for logging:
     const tmpLog = tmpFileSync({ keep: true })
     const tmpLogPipe = createWriteStream(tmpLog.name)

--- a/app/daemon.js
+++ b/app/daemon.js
@@ -38,49 +38,36 @@ export function spawnIPFSCommand (command) {
 }
 
 /**
- * Resolves true if a connection to the api could be made, false otherwise
- * @returns Promise<Boolean>
- */
-export function checkApiConnection () {
-  return getAPIVersion()
-    .then(version => {
-      if (version === pjson.ipfsVersion ||
-        version === pjson.ipfsVersion.replace('v', '')) {
-        return Promise.resolve(true)
-      } else {
-        // show alert
-      }
-      return Promise.resolve(true)
-    })
-    .catch(err => {
-      console.error('API not available', err.message)
-      return Promise.resolve(false)
-    })
-}
-
-/**
  *
- * Example:
- * ```
- * ApiVersionResult {
- *   Version: "0.4.14",
- *   Commit: "",
- *   Repo: "6",
- *   System: "amd64/linux",
- *   Golang: "go1.10"
- * }
- * ```
- * @returns Promise<ApiVersionResult>
+ * Returns the version of the currently running API.
+ * If no API is available returns `null`.
+ *
+ * Example: 'v0.4.14'
+ * @returns Promise<string>
  */
 export function getAPIVersion () {
   return request({
     // what if it's running on a different port?
     uri: 'http://localhost:5001/api/v0/version',
     headers: { 'User-Agent': `Orion/${pjson.version}` }
-  }).then(res => {
-    res = JSON.parse(res)
-    return Promise.resolve(res.Version)
   })
+    .then(res => {
+      /**
+       * ApiVersionResult {
+       *   Version: "0.4.14",
+       *   Commit: "",
+       *   Repo: "6",
+       *   System: "amd64/linux",
+       *   Golang: "go1.10"
+       * }
+       */
+      res = JSON.parse(res)
+      return Promise.resolve(`v${res.Version}`)
+    })
+    .catch(err => {
+      console.error('API not available', err.message)
+      return Promise.resolve(null)
+    })
 }
 
 /**

--- a/app/daemon.test.js
+++ b/app/daemon.test.js
@@ -1,5 +1,7 @@
 import * as daemon from './daemon'
 
+global.IPFS_REPO_PATH = '/custom/path/to/ipfs'
+
 jest.mock('electron-settings', () => {
   const getSyncMock = jest.fn()
     .mockReturnValueOnce(null)
@@ -7,13 +9,6 @@ jest.mock('electron-settings', () => {
 
   return {
     getSync: getSyncMock
-  }
-})
-jest.mock('app-root-dir', () => {
-  const getAppRootMock = jest.fn().mockReturnValue('root-dir')
-
-  return {
-    get: getAppRootMock
   }
 })
 
@@ -27,16 +22,6 @@ jest.mock('electron', () => {
 })
 
 describe('daemon.js', () => {
-  describe('getPathIPFSBinary', () => {
-    it('should always return the default value', () => {
-      // arrange
-      // act
-      const path = daemon.binaryPath
-      // assert
-      expect(path).toBe('root-dir/go-ipfs/ipfs')
-    })
-  })
-
   describe('isIPFSInitialised', () => {
     it('will correctly return if a repo conf does not exist', () => {
       const bool = daemon.isIPFSInitialised()

--- a/app/daemon.test.js
+++ b/app/daemon.test.js
@@ -31,7 +31,7 @@ describe('daemon.js', () => {
     it('should always return the default value', () => {
       // arrange
       // act
-      const path = daemon.getPathIPFSBinary()
+      const path = daemon.binaryPath
       // assert
       expect(path).toBe('root-dir/go-ipfs/ipfs')
     })

--- a/app/index.js
+++ b/app/index.js
@@ -137,7 +137,7 @@ app.on('ready', () => {
         console.log('Using API multiaddr:', global.IPFS_MULTIADDR_API)
       })
       // Start the IPFS API Client
-      .then(initIPFSClient(global.IPFS_MULTIADDR_API))
+      .then(initIPFSClient())
       .then(client => {
         console.log('Connecting to the IPFS Daemon')
         global.IPFS_CLIENT = client

--- a/app/index.js
+++ b/app/index.js
@@ -11,7 +11,7 @@ import {
   connectToCMD,
   addBootstrapAddr,
   promiseRepoUnlocked,
-  checkApiConnection,
+  getAPIVersion,
   setCustomBinaryPath,
   skipRepoPath
 } from './daemon'
@@ -62,16 +62,23 @@ app.on('ready', () => {
     // Set up crash reports.
     // Set up the needed stuff as the app launches.
 
-    checkApiConnection()
-      .then(connectionStatus => {
+    getAPIVersion()
+      .then(apiVersion => {
         let customPorts = false
 
         // An api is already available on port 5001
-        if (connectionStatus) {
+        if (apiVersion !== null) {
+          let alertMessage = 'An IPFS instance is already up!'
+          alertMessage += '\n\nWould you like Orion to connect to the available node, instead of using its own?'
+
+          if (apiVersion !== pjson.ipfsVersion) {
+            alertMessage += `\n\nPlease note: Orion was design with IPFS ${pjson.ipfsVersion} in mind, `
+            alertMessage += `while the available API is running ${apiVersion}.`
+          }
+
           const btnId = dialog.showMessageBox({
             type: 'info',
-            message: `An IPFS instance is already up!
-                      \nWould you like Orion to connect to the available node, instead of using its own?`,
+            message: alertMessage,
             buttons: ['No', 'Yes'],
             cancelId: 0,
             defaultId: 1

--- a/app/index.js
+++ b/app/index.js
@@ -94,9 +94,11 @@ app.on('ready', () => {
 
         // An api is already available on port 5001
         if (apiVersion !== null) {
+          console.log("Another service on localhost:5001 has been deteced")
           const useExistingNode = askWhichNodeToUse(apiVersion)
 
           if (useExistingNode) {
+            console.log("Using existing IPFS node (localhost:5001)")
             // Use running node, skip starting the daemon
             // Set binary path to `ipfs` to use the client's binary
             skipRepoPath()
@@ -104,6 +106,7 @@ app.on('ready', () => {
             return Promise.resolve()
           } else {
             // Use our own daemon, but on different ports
+            console.log("Using custom setup for Orion new IPFS node (localhost:5101)")
             customPorts = true
           }
         }

--- a/app/index.js
+++ b/app/index.js
@@ -3,6 +3,7 @@ import { autoUpdater } from 'electron-updater'
 import { join as pathJoin } from 'path'
 import pjson from '../package.json'
 import './report'
+import rootDir from 'app-root-dir'
 
 import {
   startIPFSDaemon,
@@ -31,7 +32,7 @@ global.IPFS_PROCESS = null
 global.IPFS_CLIENT = null
 
 // Sets default values for IPFS configurations
-global.IPFS_BINARY_PATH = 'go-ipfs/ipfs'
+global.IPFS_BINARY_PATH = `${rootDir.get()}/go-ipfs/ipfs`
 global.IPFS_MULTIADDR_API = '/ip4/127.0.0.1/tcp/5001'
 global.IPFS_MULTIADDR_GATEAY = '/ip4/127.0.0.1/tcp/8080'
 global.IPFS_MULTIADDR_SWARM = `'["/ip4/0.0.0.0/tcp/4001", "/ip6/::/tcp/4001"]'`

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "spin.js": "^2.3.2",
     "styled-components": "^3.1.6",
     "tmp": "^0.0.33",
-    "underscore": "^1.8.3"
+    "underscore": "^1.8.3",
+    "app-root-dir": "^1.0.2"
   },
   "build": {
     "appId": "io.siderus.orion",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   },
   "dependencies": {
     "@sentry/electron": "^0.5.2",
-    "app-root-dir": "^1.0.2",
     "byte-size": "^3.0.0",
     "classnames": "^2.2.5",
     "electron-compile": "^6.4.2",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "mobx-react": "^4.1.0",
     "multiaddr": "^3.0.2",
     "photon": "git+https://github.com/connors/photon.git",
-    "promised-exec": "^1.0.1",
     "query-string": "^5.1.0",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",


### PR DESCRIPTION
## What changed?
This PR allows orion to connect to an existing IPFS Api (if available at `http://localhost:5001`)
https://dev.siderus.team/issues/95
https://github.com/Siderus/Orion/issues/89