### PR TITLE
adds more linux targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     },
     "linux": {
       "target": [
-        "deb"
+        "deb", "rpm", "pacman", "apk"
       ]
     },
     "mac": {


### PR DESCRIPTION
## What changed?
This will add more packages format for multiple GNU/Linux distro
Mac pkg, dmg are not included as the docker image used seems to not have those formats

Issue number 91
