### PR TITLE
Allow to wrap multiple uploads under the same directory

### DIFF
--- a/app/api.js
+++ b/app/api.js
@@ -52,6 +52,8 @@ export function initIPFSClient () {
 }
 
 /**
+ * Wrap the given files/links under a directory.
+ *
  * ```
  * Link {
  *  hash: string;
@@ -60,7 +62,7 @@ export function initIPFSClient () {
  * }
  * ```
  *
- * @param {Link[]} links
+ * @param {Link[]} links the files to be included in the wrapper
  * @returns {Link} the wrapper, which is of type Link
  */
 export function wrapFiles (links) {
@@ -102,23 +104,14 @@ export function wrapFiles (links) {
  * }
  * ```
  *
- * @param {string|string[]} filePath
- * @returns {Wrapper} wrapper
+ * @param {string[]} filePaths
+ * @returns {Promise<Wrapper>} promise resolving with the wrapper
  */
-export function addFileOrFilesFromFSPath (filePath, _queryGateways = queryGateways) {
+export function addFilesFromFSPath (filePaths, _queryGateways = queryGateways) {
   if (!IPFS_CLIENT) return Promise.reject(ERROR_IPFS_UNAVAILABLE)
 
   const options = { recursive: true }
-
-  const promises = []
-  if (Array.isArray(filePath)) {
-    filePath.map(path => promises.push(IPFS_CLIENT.util.addFromFs(path, options)))
-  } else {
-    /**
-     * Add the file/directory from fs
-     */
-    promises.push(IPFS_CLIENT.util.addFromFs(filePath, options))
-  }
+  const promises = filePaths.map(path => IPFS_CLIENT.util.addFromFs(path, options))
 
   return Promise.all(promises)
     .then(fileUploadResults => {

--- a/app/api.test.js
+++ b/app/api.test.js
@@ -179,7 +179,7 @@ describe('api.js', () => {
       // arrange
       api.setClientInstance(null)
       // act
-      return api.addFileOrFilesFromFSPath('./fake-path')
+      return api.addFilesFromFSPath()
         .catch(err => {
           // assert
           expect(err).toBe(ERROR_IPFS_UNAVAILABLE)
@@ -228,7 +228,7 @@ describe('api.js', () => {
       })
       const queryGatewaysMock = jest.fn()
       // act
-      return api.addFileOrFilesFromFSPath('./textfiles', queryGatewaysMock)
+      return api.addFilesFromFSPath(['./textfiles'], queryGatewaysMock)
         .then(result => {
           // assert
           expect(addFromFsMock).toHaveBeenCalledWith('./textfiles', { recursive: true })
@@ -294,7 +294,7 @@ describe('api.js', () => {
       })
       const queryGatewaysMock = jest.fn()
       // act
-      return api.addFileOrFilesFromFSPath('./textfiles', queryGatewaysMock)
+      return api.addFilesFromFSPath(['./textfiles'], queryGatewaysMock)
         .then(result => {
           // assert
           expect(queryGatewaysMock).toHaveBeenCalledWith('QmRgutAxd8t7oGkSm4wmeuByG6M51wcTso6cubDdQtu001')

--- a/app/api.test.js
+++ b/app/api.test.js
@@ -176,12 +176,12 @@ describe('api.js', () => {
     })
   })
 
-  describe('addFileFromFSPath', () => {
+  describe('addFileOrFilesFromFSPath', () => {
     it('should reject when IPFS is not started', () => {
       // arrange
       api.setClientInstance(null)
       // act
-      return api.addFileFromFSPath('./fake-path')
+      return api.addFileOrFilesFromFSPath('./fake-path')
         .catch(err => {
           // assert
           expect(err).toBe(ERROR_IPFS_UNAVAILABLE)
@@ -230,7 +230,7 @@ describe('api.js', () => {
       })
       const queryGatewaysMock = jest.fn()
       // act
-      return api.addFileFromFSPath('./textfiles', queryGatewaysMock)
+      return api.addFileOrFilesFromFSPath('./textfiles', queryGatewaysMock)
         .then(result => {
           // assert
           expect(addFromFsMock).toHaveBeenCalledWith('./textfiles', { recursive: true })
@@ -245,21 +245,11 @@ describe('api.js', () => {
           expect(pinAddMock).toHaveBeenCalledWith('QmRgutAxd8t7oGkSm4wmeuByG6M51wcTso6cubDdQtu003')
           expect(pinRmMock).toHaveBeenCalledWith('QmRgutAxd8t7oGkSm4wmeuByG6M51wcTso6cubDdQtu002')
           expect(queryGatewaysMock).not.toHaveBeenCalled()
-          expect(result).toEqual([
-            {
-              hash: 'QmRgutAxd8t7oGkSm4wmeuByG6M51wcTso6cubDdQtu001',
-              path: 'textfiles/foo.txt',
-              size: 30
-            }, {
-              hash: 'QmRgutAxd8t7oGkSm4wmeuByG6M51wcTso6cubDdQtu002',
-              path: 'textfiles',
-              size: 50
-            }, {
-              hash: 'QmRgutAxd8t7oGkSm4wmeuByG6M51wcTso6cubDdQtu003',
-              path: '',
-              size: 60
-            }
-          ])
+          expect(result).toEqual({
+            hash: 'QmRgutAxd8t7oGkSm4wmeuByG6M51wcTso6cubDdQtu003',
+            path: '',
+            size: 60
+          })
         })
     })
 
@@ -306,7 +296,7 @@ describe('api.js', () => {
       })
       const queryGatewaysMock = jest.fn()
       // act
-      return api.addFileFromFSPath('./textfiles', queryGatewaysMock)
+      return api.addFileOrFilesFromFSPath('./textfiles', queryGatewaysMock)
         .then(result => {
           // assert
           expect(queryGatewaysMock).toHaveBeenCalledWith('QmRgutAxd8t7oGkSm4wmeuByG6M51wcTso6cubDdQtu001')

--- a/app/windows/Storage/fileIntegration.js
+++ b/app/windows/Storage/fileIntegration.js
@@ -1,8 +1,30 @@
 import { remote } from 'electron'
 import Settings from 'electron-settings'
-import { addFileFromFSPath, unpinObject } from '../../api'
+import { addFileOrFilesFromFSPath, unpinObject } from '../../api'
+import DetailsWindow from '../Details/window'
 
 const { app, dialog, shell } = remote
+
+/**
+ * Returns `true` if the user wants to wrap all files under a single dir,
+ * `false` otherwise
+ *
+ * @returns {boolean}
+ */
+function askWhetherToWrapAllFiles () {
+  const buttons = ['No', 'Yes']
+  const successMessageOption = {
+    type: 'info',
+    title: 'Before we do that...',
+    message: 'Would you like to wrap all these files under the same directory?',
+    cancelId: 0,
+    defaultId: 1,
+    buttons
+  }
+
+  const btnId = dialog.showMessageBox(app.mainWindow, successMessageOption)
+  return btnId === 1
+}
 
 /**
  * This function will add the files from a list of their paths, and show
@@ -11,6 +33,16 @@ const { app, dialog, shell } = remote
  * ToDo: add loading messages/feedback
  */
 export function addFilesPaths (paths) {
+  let promises
+
+  if (paths.length > 1 && askWhetherToWrapAllFiles()) {
+    // If the user says yes to wrapping all files, simply pass the paths array
+    promises = [addFileOrFilesFromFSPath(paths)]
+  } else {
+    // User wants to wrap each file
+    promises = paths.map(path => addFileOrFilesFromFSPath(path))
+  }
+
   const buttons = ['Close', 'Open in the browser']
   const successMessageOption = {
     type: 'info',
@@ -25,31 +57,27 @@ export function addFilesPaths (paths) {
     title: 'Adding the file failed'
   }
 
-  const promises = paths.map(path => addFileFromFSPath(path))
   return Promise.all(promises)
     .then(results => {
-      // building the lines of the text messages, containing the file name
-      // followed by its hash
-      const textLines = results.map(result => {
-        // we need the hash of our wrapper
-        const wrapper = result[result.length - 1]
-        // we need the path of our upload (if it's a directory it will be second to last)
-        const root = result[result.length - 2]
+      // Array of wrappers expected
+      // If the user upload only one file (or wrapped everything), open the Property Window (Details)
+      if (results.length === 1) {
+        const wrapper = results[0]
+        return DetailsWindow.create(app, wrapper.hash)
+      }
 
-        return `${wrapper.hash} ${root.path}`
-      })
+      // the old fashion way: show an alert with the `Open in browser` button
+      // building the lines of the text messages, containing only the wrappers
+      const textLines = results.map(wrapper => wrapper.hash)
 
       // ToDo: improve this, maybe show a custom window with more details.
       //       it is ugly!!!
-      successMessageOption.message += `This includes: \n${textLines.join('\n')}`
+      successMessageOption.message += `This includes the following hashes: \n${textLines.join('\n')}`
       const btnId = dialog.showMessageBox(app.mainWindow, successMessageOption)
 
       // if(btnId === buttons.indexOf('Open on the browser'))
       if (btnId === 1) {
-        openInBrowser(results.map(result => {
-          const wrapper = result[result.length - 1]
-          return wrapper.hash
-        }))
+        openInBrowser(results.map(wrapper => wrapper.hash))
       }
     })
     .catch((err) => {

--- a/app/windows/Storage/fileIntegration.js
+++ b/app/windows/Storage/fileIntegration.js
@@ -1,6 +1,6 @@
 import { remote } from 'electron'
 import Settings from 'electron-settings'
-import { addFileOrFilesFromFSPath, unpinObject } from '../../api'
+import { addFilesFromFSPath, unpinObject } from '../../api'
 import DetailsWindow from '../Details/window'
 
 const { app, dialog, shell } = remote
@@ -37,10 +37,10 @@ export function addFilesPaths (paths) {
 
   if (paths.length > 1 && askWhetherToWrapAllFiles()) {
     // If the user says yes to wrapping all files, simply pass the paths array
-    promises = [addFileOrFilesFromFSPath(paths)]
+    promises = [addFilesFromFSPath(paths)]
   } else {
-    // User wants to wrap each file
-    promises = paths.map(path => addFileOrFilesFromFSPath(path))
+    // User wants to wrap each file (this method expects an array)
+    promises = paths.map(path => addFilesFromFSPath([path]))
   }
 
   const buttons = ['Close', 'Open in the browser']


### PR DESCRIPTION
## What changed?
If the user upload one file: just open the Property Window (Details)
If the user uploads multiple files (greater than 1) ask him/she if he/she wants to wrap the files, and then show just one property window for the wrapper. Otherwise fall back on the previous behavior (show the wrappers in an alert and allow to `Open in browser`) 

This solves Redmine issue 96 and Github issue #87 