### PR TITLE
Distinguish between errors coming from releases and errors coming from development

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,11 @@ stages:
   - test
   - release
 
+before_script:
+  - mv package.json package.json.old
+  - cat package.json.old | jq 'to_entries | map(if .key == "env" then .value = "release" else . end) | from_entries' > package.json
+  - rm -f package.json.old
+
 yarn-test:
   stage: test
   tags:

--- a/app/report.js
+++ b/app/report.js
@@ -1,9 +1,8 @@
 const pjson = require('../package.json')
 const { init } = require('@sentry/electron')
-const { env } = require('process')
 
 init({
   dsn: 'https://4b375cfe65e64f2aafbc2f701d1398d0@sentry.io/1189440',
   release: `${pjson.version}/IPFS-${pjson.ipfsVersion}`,
-  environment: `${env.NODE_ENV}`
+  environment: `${pjson.env}`
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "Orion",
   "version": "0.2.2",
+  "env": "development",
   "ipfsVersion": "v0.4.14",
   "description": "Orion is an easy-to-use and KISS IPFS desktop interface",
   "main": "app/entry.js",


### PR DESCRIPTION
## What changed?
There is a new value into the `package.json` aka `env`, that is used by Sentry to identify which environment it is. Possible values:

- `release`
- `development`

The value is changed during the release/building process on GitLab
Fixes issue 107 on Redmine.