### PR TITLE
Skip download if the user didn't select a dir, fix StorageList's checkboxes

### DIFF
--- a/app/windows/Storage/Components/Header.jsx
+++ b/app/windows/Storage/Components/Header.jsx
@@ -74,15 +74,20 @@ class Header extends React.Component {
     if (selected.length > 1) {
       opts.properties = ['openDirectory', 'createDirectory']
       opts.buttonLabel = 'Save everything here'
-      const destDir = remote.dialog.showOpenDialog(remote.app.mainWindow, opts)[0]
+      const filePaths = remote.dialog.showOpenDialog(remote.app.mainWindow, opts)
+      if (!filePaths) return
 
-      promises = selected.map(element => saveFileToPath(element.hash, destDir))
+      const destination = filePaths[0]
+      promises = selected.map(element => saveFileToPath(element.hash, destination))
     } else {
       // selected.length === 1
       opts.properties = ['openDirectory']
       opts.buttonLabel = 'Save here'
-      const dest = remote.dialog.showOpenDialog(remote.app.mainWindow, opts)
-      promises = [saveFileToPath(selected[0].hash, dest[0])]
+      const filePaths = remote.dialog.showOpenDialog(remote.app.mainWindow, opts)
+      if (!filePaths) return
+
+      const destination = filePaths[0]
+      promises = [saveFileToPath(selected[0].hash, destination)]
     }
 
     this.setState({ isSavingOnDisk: true })

--- a/app/windows/Storage/Components/StorageElement.jsx
+++ b/app/windows/Storage/Components/StorageElement.jsx
@@ -1,7 +1,6 @@
 import { remote } from 'electron'
 
 import React from 'react'
-import { isEqual } from 'underscore'
 import { Icon } from 'react-photonkit'
 
 import { saveFileToPath } from '../../../api'
@@ -75,7 +74,7 @@ class StorageElement extends React.Component {
   _handleCheckboxOnClick (element, proxy, event) {
     if (!this.props.storageStore) return
 
-    if (this.props.storageStore.selected.find((el) => isEqual(el, element))) {
+    if (this.props.storageStore.selected.find(el => el.hash === element.hash)) {
       this.props.storageStore.selected.pop(element)
     } else {
       this.props.storageStore.selected.push(element)


### PR DESCRIPTION
## What changed?
Fixed https://dev.siderus.team/issues/108 (Cannot read property '0' of undefined)

While working on this I found 2 more bugs, one of which I fixed:
1. When I select a second element, `this.props.storageStore.selected.length` is actually 0, because the equality check fails (it thinks it's the same element), therefore clicking 'Download' after checking 2 items did nothing.

2. (not fixed) When downloading more than 1 item, the loading wheel never disappears even though the files were saved. I dug a bit into this and it looks like when we call `saveFileToPath` twice, the promise resolves only once. My fear is that we can't use `IPFS_CLIENT.files.getReadableStream(hash)` concurrently ... thoughts? 