### PR TITLE
Handle user cancel when choosing files to upload

### DIFF
--- a/app/windows/Storage/fileIntegration.js
+++ b/app/windows/Storage/fileIntegration.js
@@ -33,8 +33,10 @@ function askWhetherToWrapAllFiles () {
  * ToDo: add loading messages/feedback
  */
 export function addFilesPaths (paths) {
-  let promises
+  // If no paths were selected it means the user canceled
+  if (!paths) return
 
+  let promises
   if (paths.length > 1 && askWhetherToWrapAllFiles()) {
     // If the user says yes to wrapping all files, simply pass the paths array
     promises = [addFilesFromFSPath(paths)]


### PR DESCRIPTION
## What changed?
This fixes: https://dev.siderus.team/issues/110

Although the issue name is about `Cannot read map of undefined` I searched sentry and couldn't find any errors about this.

The sentry error that is linked to 110, `Cannot read length of undefined`, should be fixed by this though.