### PR TITLE
Remove shared ipfs api instance to one per window

### DIFF
--- a/app/api.js
+++ b/app/api.js
@@ -21,22 +21,14 @@ export function setClientInstance (client) {
 }
 
 /**
- * initIPFSClient will set up a new ipfs-api instance. It will try to get an
- * existing instance and the configuration (api endpoint) from global vars
+ * initIPFSClient will set up a new ipfs-api instance. It will try to get
+ * the configuration (api endpoint) from global vars
  *
  * @returns Promise<IPFS_CLIENT>
  */
 export function initIPFSClient () {
   if (IPFS_CLIENT !== null) return Promise.resolve(IPFS_CLIENT)
 
-  // get IPFS client from the main process
-  if (remote) {
-    const globalClient = remote.getGlobal('IPFS_CLIENT')
-    if (globalClient) {
-      setClientInstance(globalClient)
-      return Promise.resolve(IPFS_CLIENT)
-    }
-  }
   // Configure the endpoint for the api. It will try to get the value from the
   // global variables IPFS_MULTIADDR_APIs
   let apiMultiaddr

--- a/app/index.js
+++ b/app/index.js
@@ -32,7 +32,6 @@ app.mainWindow = null
 
 // A little space for IPFS processes
 global.IPFS_PROCESS = null
-global.IPFS_CLIENT = null
 
 // Sets default values for IPFS configurations
 global.IPFS_BINARY_PATH = `${rootDir.get()}/go-ipfs/ipfs`
@@ -184,7 +183,6 @@ function startOrion () {
       .then(initIPFSClient)
       .then(client => {
         console.log('Connecting to the IPFS Daemon')
-        global.IPFS_CLIENT = client
         loadingWindow.webContents.send('set-progress', {
           text: 'Connecting to the IPFS Daemon...',
           percentage: 40

--- a/app/windows/Details/renderer.jsx
+++ b/app/windows/Details/renderer.jsx
@@ -8,6 +8,7 @@ import {
   saveFileToPath,
   isObjectPinned,
   pinObject,
+  promiseIPFSReady,
   unpinObject
 } from '../../api'
 import { openInBrowser } from '../Storage/fileIntegration'
@@ -32,16 +33,11 @@ class DetailsWindow extends React.Component {
     currentTab: 0
   }
 
-  constructor (props) {
-    super(props)
-
-    this.handleDownload = this.handleDownload.bind(this)
-    this.handleOpenInBrowser = this.handleOpenInBrowser.bind(this)
-    this.handlePin = this.handlePin.bind(this)
-    this.handleUnpin = this.handleUnpin.bind(this)
+  componentDidMount () {
+    promiseIPFSReady().then(this.fetchData)
   }
 
-  componentDidMount () {
+  fetchData = () => {
     Promise.all([
       getObjectStat(hash),
       getObjectDag(hash),
@@ -54,7 +50,7 @@ class DetailsWindow extends React.Component {
       }))
   }
 
-  handleDownload () {
+  handleDownload = () => {
     const options = {
       title: 'Where should I save?',
       properties: ['openDirectory'],
@@ -76,11 +72,11 @@ class DetailsWindow extends React.Component {
     }
   }
 
-  handleOpenInBrowser () {
+  handleOpenInBrowser = () => {
     openInBrowser([hash])
   }
 
-  handlePin () {
+  handlePin = () => {
     this.setState({ isUpdatingPin: true })
     pinObject(hash)
       .then(result => this.setState({ isPinned: true, isUpdatingPin: false }))
@@ -90,7 +86,7 @@ class DetailsWindow extends React.Component {
       })
   }
 
-  handleUnpin () {
+  handleUnpin = () => {
     this.setState({ isUpdatingPin: true })
     unpinObject(hash)
       .then(result => this.setState({ isPinned: false, isUpdatingPin: false }))

--- a/app/windows/Settings/renderer.jsx
+++ b/app/windows/Settings/renderer.jsx
@@ -11,7 +11,7 @@ import {
   PaneGroup
 } from 'react-photonkit'
 
-import { initIPFSClient } from '../../api'
+import { initIPFSClient, promiseIPFSReady } from '../../api'
 
 import Sidebar from './Components/Sidebar'
 import RepositoryPanel from './Components/RepositoryPanel'
@@ -23,7 +23,7 @@ import InformationStore from './Stores/Information'
 
 class SettingsWindow extends React.Component {
   componentDidMount () {
-    InformationStore.loadData()
+    promiseIPFSReady().then(() => InformationStore.loadData())
   }
 
   render () {

--- a/app/windows/Storage/renderer.jsx
+++ b/app/windows/Storage/renderer.jsx
@@ -9,7 +9,8 @@ import {
   getPeersInfo,
   getRepoInfo,
   getStorageList,
-  getObjectList
+  getObjectList,
+  promiseIPFSReady
 } from '../../api'
 import { setupAddAppOnDrop } from './fileIntegration'
 
@@ -60,7 +61,7 @@ function startLoop () {
 
 class App extends React.Component {
   componentDidMount () {
-    startLoop()
+    promiseIPFSReady().then(startLoop)
   }
 
   componentWillUnmount () {


### PR DESCRIPTION
## What changed?
Now each window has its own api connection, the client is no longer shared between them.
There is a significant performance drop which can be seen (the time after the loading wheel disappears until the data is loaded into the component). 
What we can do is add a loading wheel to show the data is loading, but is this the solution we want?
Note that the bug https://dev.siderus.team/issues/125 is fixed by this change, we can now download `QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn`.
