### PR TITLE
Fix repoSize typo in api/getRepoInfo

### DIFF
--- a/app/api.js
+++ b/app/api.js
@@ -202,7 +202,7 @@ export function getRepoInfo () {
   return IPFS_CLIENT.repo.stat({ human: false })
     .then((stats) => {
       // Providing {value, unit} to the stats.RepoSize
-      stats.RepoSize = byteSize(stats.RepoSize)
+      stats.RepoSize = byteSize(stats.repoSize)
       return Promise.resolve(stats)
     })
 }


### PR DESCRIPTION
## What changed?
Repository size now shows the correct value.