### PR TITLE
Fix "run garbage collector" button

### DIFF
--- a/app/windows/Settings/Components/RepositoryPanel.jsx
+++ b/app/windows/Settings/Components/RepositoryPanel.jsx
@@ -12,14 +12,10 @@ import { runGarbageCollector } from '../../../api'
 @observer
 class RepositoryPanel extends React.Component {
   /** Perform garbage collector and reload the view when done */
-  _handleButtonGarbageCollectorClick (event) {
+  _handleButtonGarbageCollectorClick = (event) => {
+    event.preventDefault()
     runGarbageCollector()
-      .then(this.props.informationStore.loadData)
-      .then(this.forceUpdate)
-  }
-
-  _handelOnSubit (event) {
-
+      .then(() => this.props.informationStore.loadData())
   }
 
   render () {
@@ -32,23 +28,19 @@ class RepositoryPanel extends React.Component {
 
     return (
       <Pane className="settings">
-        <form onSubmit={this._handelOnSubit.bind(this)}>
+        <Input
+          label="Repository Size:"
+          type="text"
+          value={repoSize}
+          placeholder="Hey girl..." readOnly
+        />
 
-          <Input
-            label="Repository Size:"
-            type="text"
-            value={repoSize}
-            placeholder="Hey girl..." readOnly
-          />
-
-          <Button
-            onClick={this._handleButtonGarbageCollectorClick.bind(this)}
-            ptSize="large"
-            glyph="trash"
-            text="Run Garbage Collector"
-          />
-
-        </form>
+        <Button
+          onClick={this._handleButtonGarbageCollectorClick}
+          ptSize="large"
+          glyph="trash"
+          text="Run Garbage Collector"
+        />
       </Pane>
     )
   }

--- a/app/windows/Settings/Components/RepositoryPanel.jsx
+++ b/app/windows/Settings/Components/RepositoryPanel.jsx
@@ -11,7 +11,7 @@ import { runGarbageCollector } from '../../../api'
 
 @observer
 class RepositoryPanel extends React.Component {
-  /** Perform garbage collector and reload the view when done */
+  /** Perform garbage collection and refetch the data when done */
   _handleButtonGarbageCollectorClick = (event) => {
     event.preventDefault()
     runGarbageCollector()


### PR DESCRIPTION
## What changed?
Fixed bug 161 and it's related sentry issues.

The problem was how we called the `loadData` function, if it's not wrapped under an arrow function, `this` is evaluated to `undefined`.

Also fixed the refreshing: because the button is by default of type submit it caused the form to be submitted and the window to be reloaded.