### PR TITLE
Report to sentry errors that we catch

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -6,6 +6,7 @@ import Settings from 'electron-settings'
 import './lib/report/node'
 import rootDir from 'app-root-dir'
 import setupTrayIcon from './setup-tray-icon'
+import { report } from './lib/report/util'
 
 import {
   startIPFSDaemon,
@@ -274,6 +275,7 @@ function startOrion () {
         } else {
           message = JSON.stringify(err)
         }
+        report(message)
         dialog.showMessageBox({ type: 'warning', message })
         app.quit()
       })

--- a/app/lib/report/util.js
+++ b/app/lib/report/util.js
@@ -1,0 +1,14 @@
+import { captureMessage, captureException } from '@sentry/electron'
+
+export function reportAndReject (err) {
+  report(err)
+  return Promise.reject(err)
+}
+
+export function report (err) {
+  if (typeof err === 'string') {
+    captureMessage(err)
+  } else {
+    captureException(err)
+  }
+}

--- a/app/windows/Storage/Components/Header.jsx
+++ b/app/windows/Storage/Components/Header.jsx
@@ -44,8 +44,9 @@ class Header extends React.Component {
     this.setState({ isRemoving: true })
     proptAndRemoveObjects(this.props.storageStore.selected)
       .then(() => {
+        // we don't clear the items, only the selected ones
+        // we wait for the storagelist to update itself to avoid a short empty table
         this.props.storageStore.selected.clear()
-        this.props.storageStore.elements.clear()
         this.setState({ isRemoving: false })
       })
       .catch(err => {

--- a/app/windows/Storage/Components/StorageElement.jsx
+++ b/app/windows/Storage/Components/StorageElement.jsx
@@ -60,6 +60,9 @@ class StorageElement extends React.Component {
         label: 'Remove',
         click: (item) => {
           proptAndRemoveObjects([this.props.element])
+            .catch(err => {
+              remote.dialog.showErrorBox('Removing the file(s) has failed', err.message)
+            })
         }
       },
       {


### PR DESCRIPTION
## What changed?
Added a bunch of sentry reporting when api calls fail. (because we catch errors and show them to the user, sentry is not reporting them).
We might get some spam, but also some insights.