### PR TITLE
fix import from hash dialog

### DIFF
--- a/app/windows/Import/Components/Footer.jsx
+++ b/app/windows/Import/Components/Footer.jsx
@@ -4,37 +4,13 @@ import React from 'react'
 import { Toolbar, Actionbar, Button } from 'react-photonkit'
 import { observer } from 'mobx-react'
 
-import { getObjectStat, getPeersWithObjectbyHash, importObjectByHash } from '../../../api'
+import { importObjectByHash } from '../../../api'
 
 @observer
 class Footer extends React.Component {
   _handleCheckButton () {
-    const storage = this.props.statsStore
-
-    // Prepare the promise to check the Peers
-    const pPeers = getPeersWithObjectbyHash(storage.hash)
-      .then(peers => {
-        storage.peersAmount = peers.length
-        storage.isLoading = false
-        this.forceUpdate()
-      })
-
-    // Prepare the promise to check the stats
-    const pStats = getObjectStat(storage.hash)
-      .then(stats => {
-        storage.stats = stats
-        storage.isLoading = false
-        this.forceUpdate()
-      })
-
-    storage.isLoading = true
-    storage.wasLoadingStats = true
-    // Now race! The first one shows stuff!
-    Promise.race([pPeers, pStats])
-      .catch(err => {
-        storage.isLoading = false
-        remote.dialog.showErrorBox('Gurl, an error occurred', `${err}`)
-      })
+    this.props.statsStore.check()
+      .then(() => { this.forceUpdate() })
   }
 
   _handleImportButton () {

--- a/app/windows/Import/Components/Form.jsx
+++ b/app/windows/Import/Components/Form.jsx
@@ -20,7 +20,9 @@ class Form extends React.Component {
     if (isValid) {
       this.props.statsStore.hash = hash
       this.props.statsStore.isValid = isValid
-      this.forceUpdate()
+      this.props.statsStore.check()
+        .then(() => { this.forceUpdate() })
+      // this.forceUpdate()
     }
   }
 

--- a/app/windows/Import/Components/Form.jsx
+++ b/app/windows/Import/Components/Form.jsx
@@ -22,7 +22,6 @@ class Form extends React.Component {
       this.props.statsStore.isValid = isValid
       this.props.statsStore.check()
         .then(() => { this.forceUpdate() })
-      // this.forceUpdate()
     }
   }
 

--- a/app/windows/Import/Stores/Stats.js
+++ b/app/windows/Import/Stores/Stats.js
@@ -38,25 +38,18 @@ export class StatStorage {
   }
 
   check () {
-    // Prepare the promise to check the Peers
-    const pPeers = getPeersWithObjectbyHash(this.hash)
-      .then(peers => {
-        console.log('got peers', peers)
-        this.peersAmount = peers.length
-        this.isLoading = false
-      })
-
-    // Prepare the promise to check the stats
-    const pStats = getObjectStat(this.hash)
-      .then(stats => {
-        console.log('got stats')
-        this.stats = stats
-        this.isLoading = false
-      })
-
     this.isLoading = true
     this.wasLoadingStats = true
-    return Promise.all([pPeers, pStats])
+
+    return Promise.all([
+      getPeersWithObjectbyHash(this.hash),
+      getObjectStat(this.hash)
+    ])
+      .then(values => {
+        this.peersAmount = values[0].length
+        this.stats = values[1]
+        this.isLoading = false
+      })
       .catch(err => {
         this.isLoading = false
         remote.dialog.showErrorBox('Gurl, an error occurred', `${err}`)

--- a/app/windows/Import/Stores/Stats.js
+++ b/app/windows/Import/Stores/Stats.js
@@ -38,18 +38,25 @@ export class StatStorage {
   }
 
   check () {
-    this.isLoading = true
-    this.wasLoadingStats = true
-
-    return Promise.all([
-      getPeersWithObjectbyHash(this.hash),
-      getObjectStat(this.hash)
-    ])
-      .then(values => {
-        this.peersAmount = values[0].length
-        this.stats = values[1]
+    // Prepare the promise to check the Peers
+    const pPeers = getPeersWithObjectbyHash(this.hash)
+      .then(peers => {
+        console.log('got peers', peers)
+        this.peersAmount = peers.length
         this.isLoading = false
       })
+
+    // Prepare the promise to check the stats
+    const pStats = getObjectStat(this.hash)
+      .then(stats => {
+        console.log('got stats')
+        this.stats = stats
+        this.isLoading = false
+      })
+
+    this.isLoading = true
+    this.wasLoadingStats = true
+    return Promise.all([pPeers, pStats])
       .catch(err => {
         this.isLoading = false
         remote.dialog.showErrorBox('Gurl, an error occurred', `${err}`)


### PR DESCRIPTION
## What changed?
It turns out the peers do load eventually (it's just very slow), but while testing the dialog I found out some other bug: If you change the hash, it no longer tries to get the peers and size, so I move the whole method in the store and called it after the text changed and is valid. 

This fixes: https://gitlab.com/siderus/Orion/issues/2