### PR TITLE
feat: add deb.siderus.io repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ Orion*
 coverage
 yarn-error.log
 go-ipfs*
+/repo/
+.dnslink-update
+.ppa-script

--- a/app/repo/install.sh
+++ b/app/repo/install.sh
@@ -1,0 +1,3 @@
+curl -s https://deb.siderus.io/key.asc | sudo apt-key add -
+echo "deb https://deb.siderus.io/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/siderus.list
+

--- a/deb-repo-config.sh
+++ b/deb-repo-config.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+OUT="$PWD/repo"
+# KEY=""
+
+_init # Init the repo
+
+for distro in xenial bionic cosmic; do
+  add_dist "$distro" "Orion-$distro" "Orion Debian Packages"
+  add_comp "$distro" stable
+  add_comp "$distro" beta
+  add_arch "$distro" amd64
+  add_arch "$distro" i386
+done
+
+deb=$(dir -w 1 "$PWD/build" | grep ".deb$") # get deb from build folder
+add_pkg_file "$PWD/build/$deb" amd64 # add the deb
+
+fin # Update/create repo


### PR DESCRIPTION
## What changed?
 - This adds the necessary scripts for publishing the debian package at deb.siderus.io as proper repository.

## Requirements
 - Gitlab pipeline needs jq, curl, dpkg-dev, ipfs and gnupg2 installed
 - REPO_KEY env must be set to the value of the exported private key used for the repo
 - Maintainer must add repo public key as `app/repo/key.asc`
 - dnslink-update config must be present
 - Afterwards hash needs to be pinned somewhere