### PR TITLE
Add copy to clipboard to details window

### DIFF
--- a/app/components/Table.jsx
+++ b/app/components/Table.jsx
@@ -8,6 +8,16 @@ const Table = styled(PhotonTable)`
     color: #fff;
     background-color: #3260d6;
   }
+
+  tr:active:nth-child(even) {
+    color: unset;
+    background-color: #f5f5f4;
+  }
+
+  tr:active {
+    color: unset;
+    background-color: #fff;
+  }
 `
 
 export default Table

--- a/app/windows/Details/Components/InformationTab.jsx
+++ b/app/windows/Details/Components/InformationTab.jsx
@@ -1,5 +1,14 @@
 import React from 'react'
-import { Content } from 'react-photonkit'
+import { Content, Button } from 'react-photonkit'
+import Input from '../../../components/Input'
+import Table from '../../../components/Table'
+
+const _handleCopyToClipboard = (event) => {
+  event.preventDefault()
+  const input = document.getElementById('hash-input')
+  input.select()
+  document.execCommand('copy')
+}
 
 /**
  * InformationTab shows the object's stats,
@@ -10,11 +19,25 @@ function InformationTab ({ stat, hash }) {
   return (
     <Content>
       <h5 className='nav-group-title'>Information</h5>
-      <table>
+      <Table>
         <tbody>
           <tr>
             <td>ID:</td>
-            <td>{hash}</td>
+            <td>
+              <Input
+                id='hash-input'
+                type="text"
+                value={hash}
+                // using onChange instead of readOnly to allow the input to be selected
+                onChange={() => { }}
+                button={
+                  <Button
+                    glyph='doc-text'
+                    onClick={_handleCopyToClipboard}
+                  />
+                }
+              />
+            </td>
           </tr>
           <tr>
             <td>Data size:</td>
@@ -29,7 +52,7 @@ function InformationTab ({ stat, hash }) {
             <td>{stat.CumulativeSize.value} {stat.CumulativeSize.unit}</td>
           </tr>
         </tbody>
-      </table>
+      </Table>
     </Content>
   )
 }


### PR DESCRIPTION
## What changed?
Change the hash to an input so it can be copied.
Also reset the `:active` styles from photon kit to get rid of the flickering (when a table has no selection mechanism).