### PR TITLE
Adds debian repo and triggers

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,7 @@ services:
 stages:
   - test
   - release
+  - postrelease
 
 before_script:
   - mv package.json package.json.old
@@ -27,5 +28,12 @@ yarn-release:
   retry: 2
   script:
     - docker run --rm -e GH_TOKEN="${GH_TOKEN}" -v ${PWD}:/project electronuserland/builder:wine /bin/bash -c "make release_all"
+  only:
+    - master
+
+trigger-repository:
+  stage: postrelease
+  script:
+    - curl -X POST -F token=${TRIGGER_REPO_TOKEN} -F ref=master https://gitlab.com/api/v4/projects/7744513/trigger/pipeline
   only:
     - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,8 +17,6 @@ before_script:
 
 yarn-test:
   stage: test
-  tags:
-    - docker
   script:
     - docker run --rm -v ${PWD}:/project electronuserland/builder:wine /bin/bash -c "make lint test"
   only:
@@ -26,9 +24,7 @@ yarn-test:
 
 yarn-release:
   stage: release
-  when: manual
-  tags:
-    - docker
+  retry: 2
   script:
     - docker run --rm -e GH_TOKEN="${GH_TOKEN}" -v ${PWD}:/project electronuserland/builder:wine /bin/bash -c "make release_all"
   only:

--- a/README.md
+++ b/README.md
@@ -10,9 +10,31 @@ repository from an UI. It includes all the dependencies needed, and works on
 every major operative system.
 It is developed and maintained by [Siderus](https://siderus.io).
 
-To download the latest version for Windows, GNU/Linux and macOS [check the latest release](https://github.com/Siderus/Orion/releases/latest)!
-
 ![Screenshots](docs/main.png)
+
+## Download
+To download the latest version, you can [check the latest release page](https://github.com/Siderus/Orion/releases/latest)
+
+We support the following operative systems, but feel free to try it on different ones:
+
+ * macOS (latest)
+ * Windows 10
+ * GNU/Linux
+
+### Ubuntu / Debian Repository
+To download Siderus Orion for Ubuntu, you can add Siderus debian reposiotry:
+
+```
+curl https://get.siderus.io/key.public.asc | sudo apt-key add -
+echo "deb https://get.siderus.io/ apt/" | sudo tee -a /etc/apt/sources.list.d/siderus.list
+sudo apt update
+```
+
+And then you can install the `orion` package by running:
+
+```
+sudo apt install orion
+```
 
 ## About the project
 The user should be able to manage the repository by adding, downloading and

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ We support the following operative systems, but feel free to try it on different
 To download Siderus Orion for Ubuntu, you can add Siderus debian reposiotry:
 
 ```
-curl https://get.siderus.io/key.public.asc | sudo apt-key add -
+wget -qO - https://get.siderus.io/key.public.asc | sudo apt-key add -
 echo "deb https://get.siderus.io/ apt/" | sudo tee -a /etc/apt/sources.list.d/siderus.list
 sudo apt update
 ```


### PR DESCRIPTION
## What changed?
Adds Debian repository in the `Readme.md` file and adds a trigger that will perform an update of the repository on `get.siderus.io`.

This will also automate the process of deploying new versions so that the task doesn't have to be triggered automatically. It will try to deploy 3 times in case of failures.