### PR TITLE
Add generic provider for auto updates

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,6 +25,7 @@ yarn:test:
   only:
     - master
     - /release.*/
+    - tags
 
 
 yarn:build:mac:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -69,24 +69,36 @@ yarn:release:mac:
   retry: 2
   script:
     - docker run --rm -e GH_TOKEN="${GH_TOKEN}" -v ${PWD}:/project electronuserland/builder:wine /bin/bash -c "make release -e OS=Darwin -e UNAME_S=Darwin"
+  artifacts:
+    paths:
+    - build
+    expire_in: 3 months
   only:
-    - master
+    - tags
 
 yarn:release:win:
   stage: release
   retry: 2
   script:
     - docker run --rm -e GH_TOKEN="${GH_TOKEN}" -v ${PWD}:/project electronuserland/builder:wine /bin/bash -c "make release -e OS=Windows_NT"
+  artifacts:
+    paths:
+    - build
+    expire_in: 3 months
   only:
-    - master
+    - tags
 
 yarn:release:gnu:
   stage: release
   retry: 2
   script:
     - docker run --rm -e GH_TOKEN="${GH_TOKEN}" -v ${PWD}:/project electronuserland/builder:wine /bin/bash -c "make release -e OS=Linux -e UNAME_S=Linux"
+  artifacts:
+    paths:
+    - build
+    expire_in: 3 months
   only:
-    - master
+    - tags
 
 
 trigger_repository:
@@ -94,4 +106,4 @@ trigger_repository:
   script:
     - curl -X POST -F token=${TRIGGER_REPO_TOKEN} -F ref=master https://gitlab.com/api/v4/projects/7744513/trigger/pipeline
   only:
-    - master
+    - tags

--- a/app/index.js
+++ b/app/index.js
@@ -149,7 +149,7 @@ function startOrion () {
       defaultId: 1
     })
     if (btnId === 1) {
-      shell.openExternal(`${pjson.repository}/releases/latest`)
+      shell.openExternal(pjson.releasePage)
     }
   })
   autoUpdater.on('update-downloaded', (info) => {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "eslint app/ --ext .jsx --ext .js",
     "start": "electron ."
   },
+  "releasePage": "https://orion.siderus.io",
   "repository": "https://github.com/siderus/Orion",
   "keywords": [
     "electron",
@@ -81,6 +82,10 @@
     "testURL": "http://localhost/"
   },
   "build": {
+    "publish": [{
+      "provider": "generic",
+      "url": "https://get.siderus.io"
+    }],
     "appId": "io.siderus.orion",
     "files": [
       "app/**/*",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   "build": {
     "publish": [{
       "provider": "generic",
-      "url": "https://get.siderus.io"
+      "url": "https://get.siderus.io/orion"
     }],
     "appId": "io.siderus.orion",
     "files": [


### PR DESCRIPTION
## What changed?
So it turns out on linux the auto updates don't work at all. (Not even the popup saying there's a new version available). We should consider checking ourselves doing a get to the `latest.yml`.

All we need to do to move from github is to upload the artifacts to `get.siderus.io`.

On windows, the app will do a get to `https://get.siderus.io/latest.yml`, check the versions and then download `https://get.siderus.io/Orion-Setup-x.x.x.exe`.
On mac is the same process, except the file is called `latest-mac.yml`.

Before we merge we should:
- update orion.siderus.io to point to get.siderus.io and not the github releases
- add some html to get.siderus.io ?  