### PR TITLE
Remove defaultId from remove dialog

### DIFF
--- a/app/windows/Storage/fileIntegration.js
+++ b/app/windows/Storage/fileIntegration.js
@@ -149,8 +149,7 @@ export function proptAndRemoveObjects (elements) {
     detail: `This includes: \n\n${elementsDetails}\n\nOnce done, you can't restore the files.`,
     type: 'warning',
     buttons: ['Cancel', 'Ok'],
-    cancelId: 0,
-    defaultId: 1
+    cancelId: 0
   }
 
   const btnClicked = dialog.showMessageBox(app.mainWindow, opts)


### PR DESCRIPTION
## What changed?
This is related to https://gitlab.com/siderus/orion/App/issues/17 and https://github.com/Siderus/Orion/issues/136#issuecomment-403224003

Before this change (with defaultId set to 1), pressing escape would close the dialog on windows and linux and return 0, but on macOS nothing would happen.

I've looked into implementing this, listening for the keypress, but there is no way to close the dialog programatically at the moment: https://github.com/electron/electron/issues/5577 .

What I noticed though is that some dialog do close when pressing escape on mac and that is because they don't have a `defaultId`.

If we remove the `defaultId` pressing escape would work on mac as well, but that means pressing enter no longer deletes the file, but cancels the operation instead.

Thoughts?