### PR TITLE
Feature/detach cli functions

### DIFF
--- a/app/api.js
+++ b/app/api.js
@@ -565,3 +565,54 @@ export function promiseIPFSReady (timeout, ipfsApiInstance) {
     }, 1000) // every second
   })
 }
+
+/**
+ * getSiderusPeers returns a Promise that will download and return a list of
+ * multiaddress (as str) of IPFS nodes from Siderus Network.
+ */
+export function getSiderusPeers () {
+  return request({
+    uri: 'https://meta.siderus.io/ipfs/peers.txt',
+    headers: { 'User-Agent': `Orion/${pjson.version}` }
+  }).then(res => {
+    let peers
+    // split the file by endlines
+    peers = res.split(/\r?\n/)
+    // remove empty lines
+    peers = peers.filter(el => el.length > 0)
+    return Promise.resolve(peers)
+  })
+}
+
+/**
+ *
+ * Returns the version of the currently running API.
+ * If no API is available returns `null`.
+ *
+ * Example: 'v0.4.14'
+ * @returns Promise<string>
+ */
+export function getAPIVersion () {
+  return request({
+    // what if it's running on a different port?
+    uri: 'http://localhost:5001/api/v0/version',
+    headers: { 'User-Agent': `Orion/${pjson.version}` }
+  })
+    .then(res => {
+      /**
+       * ApiVersionResult {
+       *   Version: '0.4.14',
+       *   Commit: ',
+       *   Repo: '6',
+       *   System: 'amd64/linux',
+       *   Golang: 'go1.10'
+       * }
+       */
+      res = JSON.parse(res)
+      return Promise.resolve(`v${res.Version}`)
+    })
+    .catch(err => {
+      console.error('API not available', err.message)
+      return Promise.resolve(null)
+    })
+}

--- a/app/api.test.js
+++ b/app/api.test.js
@@ -445,4 +445,12 @@ describe('api.js', () => {
         })
     })
   })
+
+  describe('getSiderusPeers', () => {
+    it('should download list of peers, not empty', () => {
+      const prom = api.getSiderusPeers()
+
+      expect(prom).resolves.not.toContain('')// removes empty lines
+    })
+  })
 })

--- a/app/daemon.js
+++ b/app/daemon.js
@@ -9,9 +9,7 @@ import {
 
 import { join as pathJoin } from 'path'
 import { fileSync as tmpFileSync } from 'tmp'
-import request from 'request-promise-native'
 import { app, dialog } from 'electron'
-import pjson from '../package.json'
 import Settings from 'electron-settings'
 
 /**
@@ -71,39 +69,6 @@ export function spawnIPFSCommand (...args) {
   }
   console.log('Running', global.IPFS_BINARY_PATH, args, options)
   return spawn(global.IPFS_BINARY_PATH, args, options)
-}
-
-/**
- *
- * Returns the version of the currently running API.
- * If no API is available returns `null`.
- *
- * Example: 'v0.4.14'
- * @returns Promise<string>
- */
-export function getAPIVersion () {
-  return request({
-    // what if it's running on a different port?
-    uri: 'http://localhost:5001/api/v0/version',
-    headers: { 'User-Agent': `Orion/${pjson.version}` }
-  })
-    .then(res => {
-      /**
-       * ApiVersionResult {
-       *   Version: '0.4.14',
-       *   Commit: ',
-       *   Repo: '6',
-       *   System: 'amd64/linux',
-       *   Golang: 'go1.10'
-       * }
-       */
-      res = JSON.parse(res)
-      return Promise.resolve(`v${res.Version}`)
-    })
-    .catch(err => {
-      console.error('API not available', err.message)
-      return Promise.resolve(null)
-    })
 }
 
 /**
@@ -256,42 +221,6 @@ export function ensureRepoMigrated () {
  */
 export function getApiMultiAddress () {
   return executeIPFSCommand('config', 'Addresses.API')
-}
-
-/**
- * connectToCMD allows easily to connect to a node by specifying a str
- * multiaddress. example: connectToCMD('/ip4/192.168.0.22/tcp/4001/ipfs/Qm...')
- * returns a promise
- */
-export function connectToCMD (strMultiddr) {
-  return executeIPFSCommand('swarm', 'connect', `${strMultiddr}`)
-}
-
-/**
- * addBootstrapAddr allows easily to add a node multiaddr as a bootstrap nodes
- * example: addBootstrapAddr('/ip4/192.168.0.22/tcp/4001/ipfs/Qm...')
- * returns a promise
- */
-export function addBootstrapAddr (strMultiddr) {
-  return executeIPFSCommand('bootstrap', 'add', `${strMultiddr}`)
-}
-
-/**
- * getSiderusPeers returns a Promise that will download and return a list of
- * multiaddress (as str) of IPFS nodes from Siderus Network.
- */
-export function getSiderusPeers () {
-  return request({
-    uri: 'https://meta.siderus.io/ipfs/peers.txt',
-    headers: { 'User-Agent': `Orion/${pjson.version}` }
-  }).then(res => {
-    let peers
-    // split the file by endlines
-    peers = res.split(/\r?\n/)
-    // remove empty lines
-    peers = peers.filter(el => el.length > 0)
-    return Promise.resolve(peers)
-  })
 }
 
 /**

--- a/app/daemon.test.js
+++ b/app/daemon.test.js
@@ -34,12 +34,4 @@ describe('daemon.js', () => {
       expect(bool).toBe(false)
     })
   })
-
-  describe('getSiderusPeers', () => {
-    it('should download list of peers, not empty', () => {
-      const prom = daemon.getSiderusPeers()
-
-      expect(prom).resolves.not.toContain('')// removes empty lines
-    })
-  })
 })

--- a/app/index.js
+++ b/app/index.js
@@ -279,7 +279,6 @@ function startOrion () {
           text: 'Connecting to Siderus Network...',
           percentage: 80
         })
-        console.log('siderus peers', peers)
         // Using the CMD to connect, as the API seems not to work
         let connectPromises = peers.map(addr => { return connectTo(addr) })
         let bootstrapPromises = peers.map(addr => { return addBootstrapAddr(addr) })

--- a/app/index.js
+++ b/app/index.js
@@ -16,17 +16,17 @@ import {
   ensuresIPFSInitialised,
   ensureDaemonConfigured,
   ensureRepoMigrated,
-  getSiderusPeers,
-  connectToCMD,
-  addBootstrapAddr,
-  promiseRepoUnlocked,
-  getAPIVersion
+  promiseRepoUnlocked
 } from './daemon'
 
 import {
+  getSiderusPeers,
+  getAPIVersion,
   promiseIPFSReady,
   initIPFSClient,
-  importObjectByHash
+  importObjectByHash,
+  connectTo,
+  addBootstrapAddr
 } from './api'
 
 import LoadingWindow from './windows/Loading/window'
@@ -279,8 +279,9 @@ function startOrion () {
           text: 'Connecting to Siderus Network...',
           percentage: 80
         })
+        console.log('siderus peers', peers)
         // Using the CMD to connect, as the API seems not to work
-        let connectPromises = peers.map(addr => { return connectToCMD(addr) })
+        let connectPromises = peers.map(addr => { return connectTo(addr) })
         let bootstrapPromises = peers.map(addr => { return addBootstrapAddr(addr) })
         return Promise.all(connectPromises.concat(bootstrapPromises))
           .catch(err => {


### PR DESCRIPTION
## What changed?
Moved the following functions from `daemon.js` to `api.js`
```
  getSiderusPeers,
  connectToCMD,
  addBootstrapAddr,
  promiseRepoUnlocked,
  getAPIVersion
```