### PR TITLE
Enable Gitlab builds for get.siderus.io

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -69,7 +69,7 @@ yarn:release:all:
   stage: release
   retry: 2
   script:
-    - docker run --rm -e GH_TOKEN="${GH_TOKEN}" -v ${PWD}:/project electronuserland/builder:wine /bin/bash -c "make release_all"
+    - docker run --rm -v ${PWD}:/project electronuserland/builder:wine /bin/bash -c "make release_all"
   artifacts:
     paths:
     - build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,7 +44,7 @@ yarn:build:win:
   stage: pre-release
   retry: 2
   script:
-    - docker run --rm -v ${PWD}:/project electronuserland/builder:wine /bin/bash -c "make build -e OS=Windows_NT"
+    -  
   artifacts:
     paths:
     - build
@@ -65,41 +65,17 @@ yarn:build:gnu:
     - /release.*/
 
 
-yarn:release:mac:
+yarn:release:all:
   stage: release
   retry: 2
   script:
-    - docker run --rm -e GH_TOKEN="${GH_TOKEN}" -v ${PWD}:/project electronuserland/builder:wine /bin/bash -c "make release -e OS=Darwin -e UNAME_S=Darwin"
+    - docker run --rm -e GH_TOKEN="${GH_TOKEN}" -v ${PWD}:/project electronuserland/builder:wine /bin/bash -c "make release_all"
   artifacts:
     paths:
     - build
     expire_in: 3 months
   only:
-    - tags
-
-yarn:release:win:
-  stage: release
-  retry: 2
-  script:
-    - docker run --rm -e GH_TOKEN="${GH_TOKEN}" -v ${PWD}:/project electronuserland/builder:wine /bin/bash -c "make release -e OS=Windows_NT"
-  artifacts:
-    paths:
-    - build
-    expire_in: 3 months
-  only:
-    - tags
-
-yarn:release:gnu:
-  stage: release
-  retry: 2
-  script:
-    - docker run --rm -e GH_TOKEN="${GH_TOKEN}" -v ${PWD}:/project electronuserland/builder:wine /bin/bash -c "make release -e OS=Linux -e UNAME_S=Linux"
-  artifacts:
-    paths:
-    - build
-    expire_in: 3 months
-  only:
-    - tags
+    - master
 
 
 trigger_repository:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,7 +44,7 @@ yarn:build:win:
   stage: pre-release
   retry: 2
   script:
-    -  
+    - docker run --rm -e GH_TOKEN="${GH_TOKEN}" -v ${PWD}:/project electronuserland/builder:wine /bin/bash -c "make -e OS="Windows_NT""
   artifacts:
     paths:
     - build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,15 +9,6 @@ stages:
   - release
   - post-release
 
-before_script:
-  - mv package.json package.json.old
-  - cat package.json.old | jq 'to_entries | map(if .key == "env" then .value = "release" else . end) | from_entries' > package.json
-  - rm -f package.json.old
-  - mv package.json package.json.old
-  - cat package.json.old | jq 'to_entries | map(if .key == "statsToken" then .value = "bcd802fa2e699f85cc19e1ff6079e3c7" else . end) | from_entries' > package.json
-  - rm -f package.json.old
-
-
 yarn:test:
   stage: test
   script:
@@ -65,17 +56,31 @@ yarn:build:gnu:
     - /release.*/
 
 
-yarn:release:all:
+yarn:release:master:
   stage: release
   retry: 2
   script:
+    - make prepare_release
+    - docker run --rm -v ${PWD}:/project electronuserland/builder:wine /bin/bash -c "make release_all"
+  artifacts:
+    paths:
+    - build
+    expire_in: 1 week
+  only:
+    - master
+
+yarn:release:tag:
+  stage: release
+  retry: 2
+  script:
+    - make prepare_release
     - docker run --rm -v ${PWD}:/project electronuserland/builder:wine /bin/bash -c "make release_all"
   artifacts:
     paths:
     - build
     expire_in: 3 months
   only:
-    - master
+    - tag
 
 
 trigger_repository:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,7 +44,7 @@ yarn:build:win:
   stage: pre-release
   retry: 2
   script:
-    - docker run --rm -e GH_TOKEN="${GH_TOKEN}" -v ${PWD}:/project electronuserland/builder:wine /bin/bash -c "make -e OS="Windows_NT""
+    - docker run --rm -v ${PWD}:/project electronuserland/builder:wine /bin/bash -c "make build -e OS=Windows_NT"
   artifacts:
     paths:
     - build

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,16 @@ _prepkg: dep _test_variables
 	NODE_ENV=${NODE_ENV} ./node_modules/.bin/electron-compile app
 .PHONY: _prepkg
 
+# This endpoints updatse package.json in order to make them realease ready!
+prepare_release:
+	cat package.json | sed "s/-nightly\",$$/\",/g" >> package.new.json
+	mv package.new.json package.json
+	cat package.json | sed "s/\"development\",$$/\"release\",/g" >> package.new.json
+	mv package.new.json package.json
+	cat package.json | sed "s/\"9d407c14d888a212cf04c397a95acb7b\",$$/\"bcd802fa2e699f85cc19e1ff6079e3c7\",/g" >> package.new.json
+	mv package.new.json package.json
+.PHONY: prepare_release_values
+
 prepare_binaries: prepare_ipfs_bin prepare_repo_migrations_bin
 .PHONY: prepare_binaries
 

--- a/Makefile
+++ b/Makefile
@@ -116,12 +116,10 @@ build_all: clean
 .PHONY: build_all
 
 release: _test_variables prepare_binaries _prepkg
-	@test -n "$(GH_TOKEN)" || (echo "Variable GH_TOKEN not set"; exit 1)
-	./node_modules/.bin/build ${BUILD_ARGS} --publish onTagOrDraft
+	./node_modules/.bin/build ${BUILD_ARGS} --publish always
 .PHONY: release
 
 release_all: clean
-	@test -n "$(GH_TOKEN)" || (echo "Variable GH_TOKEN not set"; exit 1)
 	$(MAKE) release -e OS="Darwin" -e UNAME_S="Darwin"
 	$(MAKE) release -e OS="Linux" -e UNAME_S="Linux"
 	$(MAKE) release -e OS="Windows_NT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Orion",
-  "version": "0.8.0",
+  "version": "0.8.0-nightly",
   "env": "development",
   "ipfsVersion": "v0.4.17",
   "ipfsRepoMigrationsVersion": "v1.4.0",


### PR DESCRIPTION
## What changed?
This PR will enable builds on GitLab and allow us to remove this dependency over GitHub.

This will always build release packages but not upload artefacts ready for publishing in `/build`, instead it will make the artefacts available to be uploaded later on https://get.siderus.io/orion/