### PR TITLE
Runs the pipeline to build/release only on tags

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -70,7 +70,7 @@ yarn:release:master:
     - build
     expire_in: 3 months
   only:
-    - master
+    - tags
 
 
 trigger_upload:


### PR DESCRIPTION
## What changed?
We are instructing gitlab to build only when we tag for a new release