### PR TITLE
Add snap packages support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: registry.gitlab.com/siderus/toolchain
+image: electronuserland/builder:wine
 
 services:
   - docker:dind
@@ -18,14 +18,14 @@ stages:
 yarn:test:
   stage: test
   script:
-    - docker run --rm -v ${PWD}:/project electronuserland/builder:wine /bin/bash -c "make lint test"
+    - make lint test
 
 
 yarn:build:mac:
   stage: pre-release
   retry: 2
   script:
-    - docker run --rm -v ${PWD}:/project electronuserland/builder:wine /bin/bash -c "make build -e OS=Darwin -e UNAME_S=Darwin"
+    - make build -e OS=Darwin -e UNAME_S=Darwin
   artifacts:
     paths:
     - build
@@ -37,7 +37,7 @@ yarn:build:win:
   stage: pre-release
   retry: 2
   script:
-    - docker run --rm -v ${PWD}:/project electronuserland/builder:wine /bin/bash -c "make build -e OS=Windows_NT"
+    - make build -e OS=Windows_NT
   artifacts:
     paths:
     - build
@@ -49,7 +49,7 @@ yarn:build:gnu:
   stage: pre-release
   retry: 2
   script:
-    - docker run --rm -v ${PWD}:/project electronuserland/builder:wine /bin/bash -c "make build -e OS=Linux -e UNAME_S=Linux"
+    - make build -e OS=Linux -e UNAME_S=Linux
   artifacts:
     paths:
     - build
@@ -62,8 +62,7 @@ yarn:release:master:
   stage: release
   retry: 2
   script:
-    - make prepare_release
-    - docker run --rm -v ${PWD}:/project electronuserland/builder:wine /bin/bash -c "make release_all"
+    - make prepare_release release_all snap_publish
   cache: {} # Disable cache
   artifacts:
     paths:

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,10 @@ REPO_MIGRATIONS_VERSION := $(shell node -p "require('./package.json').ipfsRepoMi
 REPO_MIGRATIONS_BINARY_NAME ?= fs-repo-migrations_${REPO_MIGRATIONS_VERSION}_${TARGET}-amd64${BINARY_EXT}
 REPO_MIGRATIONS_BINARY_URL ?= https://dist.ipfs.io/fs-repo-migrations/${REPO_MIGRATIONS_VERSION}/${REPO_MIGRATIONS_BINARY_NAME}
 NODE_ENV ?= development
+TMP_DIR := $(shell mktemp -d)
+
 GH_TOKEN ?=
+SNAPCRAFT_TOKEN ?= 
 
 ifeq ($(OS),Windows_NT)
 	BINARY_EXT := .zip
@@ -125,7 +128,7 @@ build_all: clean
 	$(MAKE) build -e OS="Windows_NT"
 .PHONY: build_all
 
-release: _test_variables prepare_binaries _prepkg
+release: _test_variables prepare_release prepare_binaries _prepkg
 	./node_modules/.bin/build ${BUILD_ARGS} --publish always
 .PHONY: release
 
@@ -134,3 +137,11 @@ release_all: clean
 	$(MAKE) release -e OS="Linux" -e UNAME_S="Linux"
 	$(MAKE) release -e OS="Windows_NT"
 .PHONY: release_all
+
+# Snapcraft publishing
+snap_publish:
+	@echo "$${SNAPCRAFT_TOKEN}" >> ${TMP_DIR}/snap.txt
+	snapcraft login --with ${TMP_DIR}/snap.txt
+	snapcraft push --release=stable ./build/Orion_*.snap
+	rm ${TMP_DIR}/snap.txt
+.PHONEY: snap_publish

--- a/package.json
+++ b/package.json
@@ -106,8 +106,7 @@
       "target": [
         "deb",
         "rpm",
-        "pacman",
-        "apk"
+        "snap"
       ]
     },
     "mac": {


### PR DESCRIPTION
## What changed?

- uses directly `electron-wine` for building (no more toolchain, not needed)
- builds `snap` packages for Linux
- adds a new make target to easily publish new span packages
- enables gitlab to build the snap packages

Closes #189 

