### PR TITLE
Fix interrupted activities clearlog

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -381,16 +381,16 @@ ipcMain.on('update-activities', () => {
  * @param {Object} activities
  */
 export const filterUnfinishedActivities = (activitiesById, activities) => {
-  const ongoingActivitiesById = []
-  const ongoingActivities = {}
+  let ongoingActivitiesById = []
+  let ongoingActivities = {}
 
-  activitiesById.forEach(uuid => {
+  ongoingActivitiesById = activitiesById.filter(id => {
     const activity = activities[uuid]
+    return (!activity.finished && !activity.interrupted) || (!activity.finished)
+  })
 
-    if (!activity.finished) {
-      ongoingActivitiesById.push(activity.uuid)
-      ongoingActivities[activity.uuid] = activity
-    }
+  ongoingActivities = ongoingActivitiesById.map(id => {
+    return activities[id]
   })
 
   return {

--- a/app/index.js
+++ b/app/index.js
@@ -384,10 +384,12 @@ export const filterUnfinishedActivities = (activitiesById, activities) => {
   let ongoingActivitiesById = []
   let ongoingActivities = {}
 
-  ongoingActivitiesById = activitiesById.filter(
-    id => (!activities[id].finished && !activities[id].interrupted) || (!activities[id].finished) 
-  )
-  ongoingActivities = ongoingActivitiesById.map(id => activities[id])
+  ongoingActivitiesById = activitiesById.filter(uuid => {
+    const activity = activities[uuid]
+    return !activity.interrupted && !activity.finished
+  })
+
+  ongoingActivitiesById.forEach(uuid => { ongoingActivities[uuid] = activities[uuid] })
 
   return {
     activitiesById: ongoingActivitiesById,

--- a/app/index.js
+++ b/app/index.js
@@ -384,14 +384,10 @@ export const filterUnfinishedActivities = (activitiesById, activities) => {
   let ongoingActivitiesById = []
   let ongoingActivities = {}
 
-  ongoingActivitiesById = activitiesById.filter(id => {
-    const activity = activities[uuid]
-    return (!activity.finished && !activity.interrupted) || (!activity.finished)
-  })
-
-  ongoingActivities = ongoingActivitiesById.map(id => {
-    return activities[id]
-  })
+  ongoingActivitiesById = activitiesById.filter(
+    id => (!activities[id].finished && !activities[id].interrupted) || (!activities[id].finished) 
+  )
+  ongoingActivities = ongoingActivitiesById.map(id => activities[id])
 
   return {
     activitiesById: ongoingActivitiesById,

--- a/app/index.test.js
+++ b/app/index.test.js
@@ -23,7 +23,7 @@ jest.mock('electron', () => ({
 
 describe('index.js', () => {
   describe('clear-activities', () => {
-    it('should only clear unfinished activities', () => {
+    it('should only clear finished activities', () => {
       // arrange
       const activitiesById = [1, 2, 3]
       const activities = {
@@ -51,6 +51,42 @@ describe('index.js', () => {
         '1': {
           uuid: 1,
           finished: false,
+          foo: 'b'
+        }
+      })
+    })
+    it('should  clear interrupted activities', () => {
+      // arrange
+      const activitiesById = [1, 2, 3]
+      const activities = {
+        '1': {
+          uuid: 1,
+          finished: false,
+          interrupted: false,
+          foo: 'b'
+        },
+        '2': {
+          uuid: 2,
+          finished: true,
+          interrupted: false,
+          foo: 'a'
+        },
+        '3': {
+          uuid: 3,
+          finished: false,
+          interrupted: true,
+          foo: 'r'
+        }
+      }
+      // act
+      const result = AppIndex.filterUnfinishedActivities(activitiesById, activities)
+      // assert
+      expect(result.activitiesById).toEqual([1])
+      expect(result.activities).toEqual({
+        '1': {
+          uuid: 1,
+          finished: false,
+          interrupted: false,
           foo: 'b'
         }
       })

--- a/app/index.test.js
+++ b/app/index.test.js
@@ -55,22 +55,25 @@ describe('index.js', () => {
         }
       })
     })
-    it('should  clear interrupted activities', () => {
+    it('should clear interrupted activities', () => {
       // arrange
       const activitiesById = [1, 2, 3]
       const activities = {
+        // Going on activity:
         '1': {
           uuid: 1,
           finished: false,
           interrupted: false,
           foo: 'b'
         },
+        // Finished activity
         '2': {
           uuid: 2,
           finished: true,
           interrupted: false,
           foo: 'a'
         },
+        // Interrupted activity
         '3': {
           uuid: 3,
           finished: false,

--- a/app/menu.js
+++ b/app/menu.js
@@ -220,7 +220,11 @@ const aboutOrion = {
 }
 
 if (process.platform === 'darwin') {
-  const name = electron.app.getName()
+  let name = 'Orion'
+  if (electron.app.getName) {
+    name = electron.app.getName()
+  }
+
   template.unshift({
     label: name,
     submenu: [aboutOrion, {


### PR DESCRIPTION
## What changed?
When cleaning the Activity list now we delete also the interrupted actions (aka: when quit the app before it finishes) 

Closes #195 